### PR TITLE
Abolish RTCAL_OFFS.

### DIFF
--- a/CCS/wisp-base/globals.h
+++ b/CCS/wisp-base/globals.h
@@ -16,47 +16,56 @@
 #include "config/pin-assign.h"     /* low level pinDefs, IDs, etc. */
 
 /* Global constants */
-#define FOREVER         (1)
-#define NEVER           (0)
+#define FOREVER                         (1)
+#define NEVER                           (0)
 
-#define TRUE            (1)
-#define FALSE           (0)
+#define TRUE                            (1)
+#define FALSE                           (0)
 
-#define HIGH            (1)
-#define LOW             (0)
+#define HIGH                            (1)
+#define LOW                             (0)
 
-#define FAIL            (0)
-#define SUCCESS         (1)
+#define FAIL                            (0)
+#define SUCCESS                         (1)
 
-/** @todo write the comments for 4 below so I can actually read them... */
-#define CMDBUFF_SIZE    (30)                                            /* ? */
-#define DATABUFF_SIZE   (2+12+2)                                        /* first2/last2 are reserved. put data into B2..B13     */
-                                                                        /*      format: [storedPC|EPC|CRC16]                    */
-#define RFIDBUFF_SIZE   (1+16+2+2+50)                                   /* longest command handled is the read command for 8 wds*/
+#define CMDBUFF_SIZE                    (30)                            // Size of the command buffer in bytes.
+#define DATABUFF_SIZE                   (2+12+2)                        // Our EPC data buffer. First and last 2 bytes are reserved for PC and CRC16, so user can only use index 2-13.
+#define RFIDBUFF_SIZE                   (1+16+2+2+50)                   // Longest command the WISP can currently process is a READ command for 8 words.
+#define USRBANK_SIZE                    (32)                            // Size of the USRBANK of the WISP in the memory. But the USRBANK is never used since WISP ignores the Sel field in Query.
 
-#define USRBANK_SIZE    (32)                                            /* ? */
+/// THESE DEFINES ARE NEVER USED?
+#define RTCAL_NOM                       (2*125)         // Supposedly halfway value of RTCAL.
+#define TRCAL_NOM                       (2*265)         // Supposedly halfway value of TRCAL.
+#define CMD_PARSE_AS_OVF                (0xFF)          // This command does not even exist... "11111111"
+#define RFID_SEED                       (0x1234)        // Change this to change the RN16 selection behavior.
 
-#define RFID_SEED       (0x1234)    //change this to change the RN16 selection behavior. if using multiple tags make sure to put a
-                                    //different value on each one!! /** @todo: maybe have this generated in INFO Mems during cal*/
 
-#define CMD_PARSE_AS_QUERY_REP          (0x00)                          /** @todo   describe these myst vals!                   */
-#define CMD_PARSE_AS_OVF                (0xFF)
+#define CMD_PARSE_AS_QUERY_REP          (0x00)          // The WISP ignores the Session fields/parameters. So when we get bits "00", we don't wait for more bits to come in and fill cmd[0] with 0x00 (all zeroes).
 #define ENOUGH_BITS_TO_FORCE_EXECUTION  (200)
 
-#define RESET_BITS_VAL  (-1)        /* this is the value which will reset the TA1_SM if found in 'bits (R5)' by rfid_sm         */
+#define RESET_BITS_VAL                  (-1)            // this is the value which will reset the TA1_SM if found in 'bits (R5)' by rfid_sm         */
 
-//RFID TIMING DEFS                      /*4.08MHz                                                                                   */
-/** @todo map these better based on full range of valid vals!                                                                   */
-//Impinj Uses RTCal = 31.4us = 2.5*TARI (min possible.   RTCal goes between 2.5-3.0 TARI Per Spec)
+// R420 TIMINGS
+#define RTCAL_MIN                       (250)           // 2.5*TARI = 2.5*6.25 = 15.625 us
+#define RTCAL_MAX                       (300)           // 3*TARI = 3*6.25 = 18.75 us
+#define TRCAL_MIN                       (275)           // We don't have time to do a MUL instruction, so we do 1.1*RTCAL_MIN instead of 1.1*RTCAL.
+#define TRCAL_MAX                       (900)           // We don't have time to do a MUL instruction, so we do 3*RTCAL_MAX instead of 3*RTCAL.
+
+// R1000 TIMINGS
+//#define RTCAL_MIN                       (285)           // 2.5*TARI = 2.5*7.14 = 17.85 us (R1000)
+//#define RTCAL_MAX                       (342)           // 3*TARI = 3*7.14 = 21.42 us (R1000)
+//#define TRCAL_MIN                       (313)           // We don't have time to do a MUL instruction, so we do 1.1*RTCAL_MIN instead of 1.1*RTCAL.
+//#define TRCAL_MAX                       (1026)          // We don't have time to do a MUL instruction, so we do 3*RTCAL_MAX instead of 3*RTCAL.
+
+/* Abolishing RTCAL_OFFS
 #define RTCAL_MIN       (250-53)
-#define RTCAL_NOM       (2*125)      /* (really only saw spread from 102 at high power to 96 at low power)  Never called         */
-#define RTCAL_MAX       (300)//(300-32)     /*(this accounts for readers who use up to 3TARI, plus a little wiggle room)               */
-#define RTCAL_OFFS      (42)         /* This is just the PW value that is not measured by the timer.                             */
+#define RTCAL_MAX       (300)//(300-32)     //(this accounts for readers who use up to 3TARI, plus a little wiggle room)
+#define RTCAL_OFFS      (42)         // This is just the PW value that is not measured by the timer.
+#define TRCAL_MIN                       (197)           // This is a super ugly hack because the timer knows the exact value of PW and we don't!
+#define TRCAL_MAX                       (930)           //
+#define FORCE_SKIP_INTO_RTCAL   (24)                    // after delim, wait till data0 passes before starting TA1_SM.
+*/
 
-//Impinj Uses TRCal = 50.2us = 1.6*RTCAL(middle of road. TRCal goes between 1.1-3 RTCAL per spec. also said, 2.75-9.00 TARI)
-#define TRCAL_MIN       (197)  // This is a super ugly hack because the timer knows the exact value of PW and we don't!
-#define TRCAL_NOM       (2*265)     /* (really only saw spread from 193 at high power to 192 at low power)                      */
-#define TRCAL_MAX       (930)  //
 
 //TIMING----------------------------------------------------------------------------------------------------------------------------//
 //Goal is 56.125/62.500/68.875us. Trying to shoot for the lower to save (a little) power.
@@ -70,8 +79,6 @@
 #define TX_TIMING_READ  (29)//58.0us
 #define TX_TIMING_WRITE (31)//60.4us
 
-#define FORCE_SKIP_INTO_RTCAL   (24)                    /* after delim, wait till data0 passes before starting TA1_SM. note     */
-                                                            /* changing this will affect timing criteria on RTCal measurement       */
 //PROTOCOL DEFS---------------------------------------------------------------------------------------------------------------------//
 //(if # is rounded to 8 that is so  cmd[n] was finished being shifted in)
 #define NUM_SEL_BITS    (48)    /* only need to parse through mask: (4+3+3+2+8+8+16 = 44 -> round to 48)                        */
@@ -100,26 +107,23 @@
 #include <stdint.h>                                                     /* use xintx_t good var defs (e.g. uint8_t)             */
 #include "config/wispGuts.h"
 
-//TYPEDEFS----------------------------------------------------------------------------------------------------------------------------
-//THE RFID STRUCT FOR INVENTORY STATE VARS
+// TYPEDEFS----------------------------------------------------------------------------------------------------------------------------
+// THE RFID STRUCT FOR INVENTORY STATE VARS
 typedef struct {
-    uint8_t     TRext;                      /** @todo What is this member? */
-    uint16_t    handle;                     /** @todo What is this member? */
-    uint16_t    slotCount;                  /** @todo What is this member? */
-    uint8_t     Q;                          /** @todo What is this member? */
-
-    uint8_t     mode;                       /** @todo What is this member? */
-    uint8_t     abortOn;                    /*  List of command responses which cause the main RFID loop to return              */
-    uint8_t     abortFlag;                  /** @todo What is this member? */
-    uint8_t     isSelected;                 /* state of being selected via the select command. Zero if not selected             */
-
-    uint8_t     rn8_ind;                    /* using our RN values in INFO_MEM, this points to the current one to use next      */
-
-    uint16_t	edge_capture_prev_ccr;		/* Previous value of CCR register, used to compute delta in edge capture ISRs		*/
+	uint8_t     TRext;                      // Query command field that decides whether we need to prepend the T=>R preamble with a pilot tone as described in 6.3.1.3.2.2
+	uint16_t    handle;                     /** @todo What is this member? */
+	uint16_t    slotCount;                  // Slot counter of the WISP used in various Gen2 commands.
+	uint8_t     Q;                          // Query command field that sets the number of slots in the round (see 6.3.2.10)
+	uint8_t     mode;                       // Query command field that tells the tag which modulation mode it should run.
+	uint8_t     abortOn;                    /*  List of command responses which cause the main RFID loop to return              */
+	uint8_t     abortFlag;                  /** @todo What is this member? */
+	uint8_t     isSelected;                 /* state of being selected via the select command. Zero if not selected             */
+	uint8_t     rn8_ind;                    /* using our RN values in INFO_MEM, this points to the current one to use next      */
+	uint16_t	edge_capture_prev_ccr;		/* Previous value of CCR register, used to compute delta in edge capture ISRs		*/
 
     /** @todo Add the following: CMD_enum latestCmd; */
 
-}RFIDstruct;                                /* in MODE_USES_SEL!!                                                               */
+} RFIDstruct;                                /* in MODE_USES_SEL!!                                                               */
 
 extern RFIDstruct   rfid;
 

--- a/CCS/wisp-base/globals.h
+++ b/CCS/wisp-base/globals.h
@@ -33,38 +33,16 @@
 #define RFIDBUFF_SIZE                   (1+16+2+2+50)                   // Longest command the WISP can currently process is a READ command for 8 words.
 #define USRBANK_SIZE                    (32)                            // Size of the USRBANK of the WISP in the memory. But the USRBANK is never used since WISP ignores the Sel field in Query.
 
-/// THESE DEFINES ARE NEVER USED?
-#define RTCAL_NOM                       (2*125)         // Supposedly halfway value of RTCAL.
-#define TRCAL_NOM                       (2*265)         // Supposedly halfway value of TRCAL.
-#define CMD_PARSE_AS_OVF                (0xFF)          // This command does not even exist... "11111111"
-#define RFID_SEED                       (0x1234)        // Change this to change the RN16 selection behavior.
-
-
-#define CMD_PARSE_AS_QUERY_REP          (0x00)          // The WISP ignores the Session fields/parameters. So when we get bits "00", we don't wait for more bits to come in and fill cmd[0] with 0x00 (all zeroes).
+#define CMD_PARSE_AS_QUERY_REP          (0x20)          // The WISP ignores the Session fields/parameters. So when we get bits "00", we don't wait for more bits to come in and fill cmd[0] with 0x20 "00100000".
 #define ENOUGH_BITS_TO_FORCE_EXECUTION  (200)
 
 #define RESET_BITS_VAL                  (-2)            // this is the value which will reset the TA1_SM if found in 'bits (R5)' by rfid_sm         */
 
-// R420 TIMINGS
-#define RTCAL_MIN                       (250)           // 2.5*TARI = 2.5*6.25 = 15.625 us
+// RFID TIMINGS (Taken a bit more liberately to support both R420 and R1000).
+#define RTCAL_MIN                       (200)           // strictly calculated it should be 2.5*TARI = 2.5*6.25 = 15.625 us = 250 cycles
 #define RTCAL_MAX                       (300)           // 3*TARI = 3*6.25 = 18.75 us
-#define TRCAL_MIN                       (275)           // We don't have time to do a MUL instruction, so we do 1.1*RTCAL_MIN instead of 1.1*RTCAL.
+#define TRCAL_MIN                       (220)           // We don't have time to do a MUL instruction, so we do 1.1*RTCAL_MIN instead of 1.1*RTCAL.
 #define TRCAL_MAX                       (900)           // We don't have time to do a MUL instruction, so we do 3*RTCAL_MAX instead of 3*RTCAL.
-
-// R1000 TIMINGS
-//#define RTCAL_MIN                       (285)           // 2.5*TARI = 2.5*7.14 = 17.85 us (R1000)
-//#define RTCAL_MAX                       (342)           // 3*TARI = 3*7.14 = 21.42 us (R1000)
-//#define TRCAL_MIN                       (313)           // We don't have time to do a MUL instruction, so we do 1.1*RTCAL_MIN instead of 1.1*RTCAL.
-//#define TRCAL_MAX                       (1026)          // We don't have time to do a MUL instruction, so we do 3*RTCAL_MAX instead of 3*RTCAL.
-
-/* Abolishing RTCAL_OFFS
-#define RTCAL_MIN       (250-53)
-#define RTCAL_MAX       (300)//(300-32)     //(this accounts for readers who use up to 3TARI, plus a little wiggle room)
-#define RTCAL_OFFS      (42)         // This is just the PW value that is not measured by the timer.
-#define TRCAL_MIN                       (197)           // This is a super ugly hack because the timer knows the exact value of PW and we don't!
-#define TRCAL_MAX                       (930)           //
-#define FORCE_SKIP_INTO_RTCAL   (24)                    // after delim, wait till data0 passes before starting TA1_SM.
-*/
 
 
 //TIMING----------------------------------------------------------------------------------------------------------------------------//

--- a/CCS/wisp-base/globals.h
+++ b/CCS/wisp-base/globals.h
@@ -43,7 +43,7 @@
 #define CMD_PARSE_AS_QUERY_REP          (0x00)          // The WISP ignores the Session fields/parameters. So when we get bits "00", we don't wait for more bits to come in and fill cmd[0] with 0x00 (all zeroes).
 #define ENOUGH_BITS_TO_FORCE_EXECUTION  (200)
 
-#define RESET_BITS_VAL                  (-1)            // this is the value which will reset the TA1_SM if found in 'bits (R5)' by rfid_sm         */
+#define RESET_BITS_VAL                  (-2)            // this is the value which will reset the TA1_SM if found in 'bits (R5)' by rfid_sm         */
 
 // R420 TIMINGS
 #define RTCAL_MIN                       (250)           // 2.5*TARI = 2.5*6.25 = 15.625 us

--- a/CCS/wisp-base/rfid/RX_ISR.asm
+++ b/CCS/wisp-base/rfid/RX_ISR.asm
@@ -11,25 +11,13 @@
 ;*   Purpose:
 ;*   This ISR kicks in on a falling edge and tries to find the rising edge marking the end of the delimiter of a PREAMBLE/FRAME-SYNC.
 ;*   After that, we disable PORT1 interrupts and setup Timer0A0.
-;*   During this preparation, some shenanigans happen, because we are already in data-0.
-;*   Since we don't actually need to read data-0 for anything, we just wait a bit until we are past data-0.
-;*   Unfortunately, preparation + delay takes too long and we are already inside RTCAL, which we DO need to measure the length of.
-;*   So we reset the timer and add X clock cycles to make it look like the clock started at the start of RTCAL.
-;*   After all that, we go back to sleep and wait for Timer0A0 to wake us up on a falling edge.
+;*   In the worst case (readers with 6.25 Tari), we only have 0.475*6.25 us = 47 clock cycles) before the falling edge of data-0.
+;*   Then we quickly return from this interrupt and wait for Timer0A0 to wake us up on the data-0 falling edge.
 ;*   An ASCII drawing of the situation can be found below:
 ;*
 ;*   |   data-0  |           RTCAL             |
 ;*   /-----\_____/------------------------\____/   - Wave form
 ;*
-;*   ------------|--X--|---S                       - Instructions being executed.
-;*               ^     ^
-;*               ^     This is where we reset the timer.
-;*               This point is where RTCAL should actually start.
-;*
-;*   TODO: Can we do this without going into RTCAL?
-;*         Modify RX state machine so we get into Timer0A0_ISR during the PW of data-0 and get rid of RTCAL_OFFS in globals.h
-;*         This will also get rid of the delimDelay and the need of resetting the clock.
-;*         We might just have enough time to do that on 16 MHz (worst case with R420, we have 0.475*6.25 us = 47 clock cycles).
 ;*************************************************************************************************************************************
 
 	.cdecls C, LIST, "../globals.h"


### PR DESCRIPTION
This fix will get rid of all delay elements in RX_ISR.
Moreover, it also improves the R420 performance by at least 5x.
